### PR TITLE
Remove textInputContextIdentifier so emoji keyboard correctly displays

### DIFF
--- a/Sources/EmojiUtilities/EmojiField_iOS.swift
+++ b/Sources/EmojiUtilities/EmojiField_iOS.swift
@@ -40,10 +40,6 @@ public class EmojiField: UIControl {
 
     // MARK: - UIResponder
 
-    public override var textInputContextIdentifier: String? {
-        "emoji"
-    }
-
     public override var textInputMode: UITextInputMode? {
         for mode in UITextInputMode.activeInputModes {
              if mode.primaryLanguage == "emoji" {


### PR DESCRIPTION
With `textInputContextIdentifier` present, `textInputMode` is never called and therefore the desired keyboard is not automatically displayed.

This PR removes `textInputContextIdentifier` to address this problem.